### PR TITLE
Add autogenerated documentation with Sphinx

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,69 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../../src'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'PecanPy'
+copyright = '2020, Renming Liu and Arjun Krishnan'
+author = 'Renming Liu and Arjun Krishnan'
+
+# The full version, including alpha/beta/rc tags
+release = '0.0.1'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.todo',
+    'sphinx.ext.coverage',
+    'sphinx.ext.viewcode',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+# html_static_path = ['_static']
+
+# Example configuration for intersphinx: refer to the Python standard library.
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'networkx': ('https://networkx.github.io/documentation/latest/', None),
+}
+
+autodoc_member_order = 'bysource'
+autoclass_content = 'both'

--- a/docs/source/graph.rst
+++ b/docs/source/graph.rst
@@ -1,0 +1,4 @@
+Graph Data Structures
+=====================
+.. autoclass:: pecanpy.graph.SparseGraph
+.. autoclass:: pecanpy.graph.DenseGraph

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,21 @@
+.. PecanPy documentation master file, created by
+   sphinx-quickstart on Fri Oct  2 23:06:32 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to PecanPy's documentation!
+===================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   graph
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`


### PR DESCRIPTION
References #13 (but doesn't close it). After checking out this PR, you can learn a bit about how to use Sphinx to automatically incorporate your documentation into the Sphinx build. To build the docs, you'll start in the root of the repository and do the following in the bash:

```bash
pip install sphinx sphinx_rtd_theme # only have to do this once
cd docs
make html
open build/html/index.html
```

Rerun the `make html` command any time you make a change