### PR TITLE
Bug fix: dtype error when converting to unweighted dense graph

### DIFF
--- a/src/pecanpy/graph.py
+++ b/src/pecanpy/graph.py
@@ -311,7 +311,7 @@ class DenseGraph:
         self.data = raw["data"]
         self.nonzero = self.data != 0
         if not weighted:  # convert edge weights to binary
-            self.data = self.nonzero * 1
+            self.data = self.nonzero * 1.0
         self.IDlst = list(raw["IDs"])
         self.IDmap = {j: i for i, j in enumerate(self.IDlst)}
 


### PR DESCRIPTION
Encountered the following error when trying to run PecanPy using the saved dense graph (``.npz`` file) for an unweighted graph. It turns out the issue was that when overwriting the original weighted adjacency using the ``nonzero`` indicator, the data type was incorrectly set to ``int64`` instead of ``float64``. This is resolved by multiplying ``1.0`` instead of ``1``.

```txt
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/ufs18/home-026/liurenmi/repo/PecanPy/src/pecanpy/node2vec.py", line 205, in embed
    walks = self.simulate_walks(num_walks=num_walks, walk_length=walk_length)
  File "/mnt/ufs18/home-026/liurenmi/repo/PecanPy/src/pecanpy/node2vec.py", line 149, in simulate_walks
    walks = [[self.IDlst[idx] for idx in walk[:walk[-1]]] for walk in node2vec_walks()]
  File "/mnt/home/liurenmi/software/anaconda3/envs/pecanpy-dev/lib/python3.8/site-packages/numba/core/dispatcher.py", line 420, in _compile_for_args
    error_rewrite(e, 'typing')
  File "/mnt/home/liurenmi/software/anaconda3/envs/pecanpy-dev/lib/python3.8/site-packages/numba/core/dispatcher.py", line 361, in error_rewrite
    raise e.with_traceback(None)
numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
Failed in nopython mode pipeline (step: nopython frontend)
Failed in nopython mode pipeline (step: nopython frontend)
No implementation of function Function(<built-in function itruediv>) found for signature:
 
 >>> itruediv(array(int64, 1d, C), Literal[int](1))
 
There are 6 candidate implementations:
  - Of which 2 did not match due to:
  Overload in function 'NumpyRulesInplaceArrayOperator.generic': File: numba/core/typing/npydecl.py: Line 213.
    With argument(s): '(array(int64, 1d, C), int64)':
   Rejected as the implementation raised a specific error:
     AttributeError: 'NoneType' object has no attribute 'args'
  raised from /mnt/home/liurenmi/software/anaconda3/envs/pecanpy-dev/lib/python3.8/site-packages/numba/core/typing/npydecl.py:224
  - Of which 2 did not match due to:
  Operator Overload in function 'itruediv': File: unknown: Line unknown.
    With argument(s): '(array(int64, 1d, C), int64)':
   No match for registered cases:
    * (int64, int64) -> float64
    * (int64, uint64) -> float64
    * (uint64, int64) -> float64
    * (uint64, uint64) -> float64
    * (float32, float32) -> float32
    * (float64, float64) -> float64
    * (complex64, complex64) -> complex64
    * (complex128, complex128) -> complex128
  - Of which 2 did not match due to:
  Overload of function 'itruediv': File: numba/core/typing/npdatetime.py: Line 94.
    With argument(s): '(array(int64, 1d, C), int64)':
   No match.

During: typing of intrinsic-call at /mnt/ufs18/home-026/liurenmi/repo/PecanPy/src/pecanpy/graph.py (388)

File "../../../PecanPy/src/pecanpy/graph.py", line 388:
    def get_normalized_probs(data, nonzero, p, q, cur_idx, prev_idx, average_weight_ary):
        <source elided>

            unnormalized_probs[non_com_nbr] /= q  # apply out biases
            ^

During: resolving callee type: type(CPUDispatcher(<function DenseGraph.get_normalized_probs at 0x2ac851660700>))
During: typing of call at /mnt/ufs18/home-026/liurenmi/repo/PecanPy/src/pecanpy/node2vec.py (418)

During: resolving callee type: type(CPUDispatcher(<function DenseGraph.get_normalized_probs at 0x2ac851660700>))
During: typing of call at /mnt/ufs18/home-026/liurenmi/repo/PecanPy/src/pecanpy/node2vec.py (418)


File "../../../PecanPy/src/pecanpy/node2vec.py", line 418:
        def move_forward(cur_idx, prev_idx=None):
            <source elided>
            """Move to next node."""
            normalized_probs = get_normalized_probs(
            ^

During: resolving callee type: type(CPUDispatcher(<function DenseOTF.get_move_forward.<locals>.move_forward at 0x2ac8956e71f0>))
During: typing of call at /mnt/ufs18/home-026/liurenmi/repo/PecanPy/src/pecanpy/node2vec.py (126)

During: resolving callee type: type(CPUDispatcher(<function DenseOTF.get_move_forward.<locals>.move_forward at 0x2ac8956e71f0>))
During: typing of call at /mnt/ufs18/home-026/liurenmi/repo/PecanPy/src/pecanpy/node2vec.py (126)


File "../../../PecanPy/src/pecanpy/node2vec.py", line 126:
        def node2vec_walks():
            <source elided>
                        prev_idx = walk_idx_mat[i, j - 2]
                        walk_idx_mat[i, j] = move_forward(cur_idx, prev_idx)
                        ^
```