### PR TITLE
Save as edgelist file

### DIFF
--- a/src/pecanpy/graph.py
+++ b/src/pecanpy/graph.py
@@ -90,14 +90,14 @@ class AdjlstGraph(BaseGraph):
         self._num_edges = 0
 
     @property
-    def edges_iter(self) -> Iterator[Tuple[str, str, float]]:
+    def edges_iter(self) -> Iterator[Tuple[int, int, float]]:
         """Return an iterator that iterates over all edges."""
         for head, head_nbrs in enumerate(self._data):
             for tail in sorted(head_nbrs):
                 yield head, tail, head_nbrs[tail]
 
     @property
-    def edges(self) -> List[Tuple[str, str, float]]:
+    def edges(self) -> List[Tuple[int, int, float]]:
         """Return a list of triples (head, tail, weight) representing edges."""
         return list(self.edges_iter)
 
@@ -237,10 +237,9 @@ class AdjlstGraph(BaseGraph):
         """
         with open(fp, "w") as f:
             for h, t, w in self.edges_iter:
-                h, t = self.nodes[h], self.nodes[t]  # convert index to node id
-                line = delimiter.join((h, t) if unweighted else (h, t, str(w)))
-                f.write(line)
-                f.write("\n")
+                h_id, t_id = self.nodes[h], self.nodes[t]
+                terms = (h_id, t_id) if unweighted else (h_id, t_id, str(w))
+                f.write(f"{delimiter.join(terms)}\n")
 
     def to_csr(self):
         """Construct compressed sparse row matrix."""

--- a/src/pecanpy/graph.py
+++ b/src/pecanpy/graph.py
@@ -1,9 +1,9 @@
 """Lite graph objects used by pecanpy."""
-import itertools
-import numpy as np
 from typing import Iterator
 from typing import List
 from typing import Tuple
+
+import numpy as np
 
 
 class BaseGraph:
@@ -22,6 +22,7 @@ class BaseGraph:
 
     @property
     def nodes(self):
+        """Return the list of node IDs."""
         return self.IDlst
 
     @property

--- a/src/pecanpy/graph.py
+++ b/src/pecanpy/graph.py
@@ -77,6 +77,8 @@ class AdjlstGraph(BaseGraph):
         >>> indptr, indices, data = g.to_csr()  # convert to csr
         >>>
         >>> dense_mat = g.to_dense()  # convert to dense adjacency matrix
+        >>>
+        >>> g.save(edg_outpath)  # save the graph to an edge list file
 
     """
 
@@ -221,6 +223,23 @@ class AdjlstGraph(BaseGraph):
             for edge_line in f:
                 edge = self._read_edge_line(edge_line, weighted, delimiter)
                 self.add_edge(*edge, directed)
+
+    def save(self, fp: str, unweighted: bool = False, delimiter: str = "\t"):
+        """Save AdjLst as an ``.edg`` edge list file.
+
+        Args:
+            unweighted (bool): If set to True, only write two columns,
+                corresponding to the head and tail nodes of the edges, and
+                ignore the edge weights (default: :obj:`False`).
+            delimiter (str): Delimiter for separating fields.
+
+        """
+        with open(fp, "w") as f:
+            for h, t, w in self.edges_iter:
+                h, t = self.nodes[h], self.nodes[t]  # convert index to node id
+                line = delimiter.join((h, t) if unweighted else (h, t, str(w)))
+                f.write(line)
+                f.write("\n")
 
     def to_csr(self):
         """Construct compressed sparse row matrix."""

--- a/src/pecanpy/graph.py
+++ b/src/pecanpy/graph.py
@@ -1,5 +1,9 @@
 """Lite graph objects used by pecanpy."""
+import itertools
 import numpy as np
+from typing import Iterator
+from typing import List
+from typing import Tuple
 
 
 class BaseGraph:
@@ -15,6 +19,10 @@ class BaseGraph:
         """Initialize ID list and ID map."""
         self.IDlst = []
         self.IDmap = {}  # id -> index
+
+    @property
+    def nodes(self):
+        return self.IDlst
 
     @property
     def num_nodes(self):
@@ -77,6 +85,18 @@ class AdjlstGraph(BaseGraph):
         super().__init__()
         self._data = []  # list of dict of node_indexx -> edge_weight
         self._num_edges = 0
+
+    @property
+    def edges_iter(self) -> Iterator[Tuple[str, str, float]]:
+        """Return an iterator that iterates over all edges."""
+        for head, head_nbrs in enumerate(self._data):
+            for tail in sorted(head_nbrs):
+                yield head, tail, head_nbrs[tail]
+
+    @property
+    def edges(self) -> List[Tuple[str, str, float]]:
+        """Return a list of triples (head, tail, weight) representing edges."""
+        return list(self.edges_iter)
 
     @property
     def num_edges(self):

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -87,6 +87,29 @@ class TestAdjlstGraph(unittest.TestCase):
         self.assertEqual(self.g.num_edges, 8)
         self.assertEqual(self.g.density, 2 / 5)
 
+    def test_edges(self):
+        self.g = AdjlstGraph.from_mat(MAT, IDS)
+        self.assertEqual(
+            list(self.g.edges),
+            [(0, 1, 1), (0, 2, 1), (1, 0, 1), (2, 0, 1)],
+        )
+
+    def test_edges2(self):
+        self.g = AdjlstGraph.from_mat(MAT2, IDS2)
+        self.assertEqual(
+            list(self.g.edges),
+            [
+                (0, 1, 1),
+                (1, 0, 1),
+                (1, 2, 1),
+                (1, 3, 1),
+                (2, 1, 1),
+                (3, 1, 1),
+                (3, 4, 1),
+                (4, 3, 1),
+            ],
+        )
+
 
 class TestSparseGraph(unittest.TestCase):
     def tearDown(self):

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -1,3 +1,6 @@
+import tempfile
+import os
+import shutil
 import unittest
 
 import numpy as np
@@ -109,6 +112,48 @@ class TestAdjlstGraph(unittest.TestCase):
                 (4, 3, 1),
             ],
         )
+
+    def test_save(self):
+        self.g = AdjlstGraph.from_mat(MAT, IDS)
+
+        expected_results = {
+            (False, "\t"): [
+                "a\tb\t1.0\n",
+                "a\tc\t1.0\n",
+                "b\ta\t1.0\n",
+                "c\ta\t1.0\n",
+            ],
+            (True, "\t"): [
+                "a\tb\n",
+                "a\tc\n",
+                "b\ta\n",
+                "c\ta\n",
+            ],
+            (False, ","): [
+                "a,b,1.0\n",
+                "a,c,1.0\n",
+                "b,a,1.0\n",
+                "c,a,1.0\n",
+            ],
+            (True, ","): [
+                "a,b\n",
+                "a,c\n",
+                "b,a\n",
+                "c,a\n",
+            ],
+        }
+
+        tmpdir = tempfile.mkdtemp()
+        tmpfp = os.path.join(tmpdir, "test.edg")
+        for unweighted in True, False:
+            for delimiter in ["\t", ","]:
+                self.g.save(tmpfp, unweighted=unweighted, delimiter=delimiter)
+
+                with open(tmpfp, "r") as f:
+                    expected_result = expected_results[(unweighted, delimiter)]
+                    for line, expected_line in zip(f, expected_result):
+                        self.assertEqual(line, expected_line)
+        shutil.rmtree(tmpdir)
 
 
 class TestSparseGraph(unittest.TestCase):


### PR DESCRIPTION
This PR implements the ``save`` method for ``AdjLst`` graph object, which saves the graph as an edge list file (with the option of weighted/unweighted and the choice of delimiter).