### PR TITLE
Pass delimiter through when using cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Another supported input format (only for `DenseOTF`) is the numpy array `.npz` f
 pecanpy --input $input_edgelist --output $output_npz --task todense
 ```
 
+The default delimiter for `.edg` is tab space (`\t`), you many change this by passing in the `--delimiter` option.
+
 ### Output
 
 The output file has *n+1* lines for graph with *n* vertices, with a header line of the following format:

--- a/src/pecanpy/cli.py
+++ b/src/pecanpy/cli.py
@@ -151,6 +151,13 @@ def parse_args():
         help="Noisy edge threshold parameter.",
     )
 
+    parser.add_argument(
+        "--delimiter",
+        type=str,
+        default='\t',
+        help="Delimiter used bewteen node IDs.",
+    )
+
     return parser.parse_args()
 
 
@@ -244,6 +251,7 @@ def read_graph(args):
     gamma = args.gamma
     mode = args.mode
     task = args.task
+    delimiter = args.delimiter
 
     if directed and extend:
         raise NotImplementedError("Node2vec+ not implemented for directed graph yet.")
@@ -253,7 +261,7 @@ def read_graph(args):
 
     if task in ["tocsr", "todense"]:  # perform conversion then save and exit
         g = graph.SparseGraph() if task == "tocsr" else graph.DenseGraph()
-        g.read_edg(fp, weighted, directed)
+        g.read_edg(fp, weighted, directed, delimiter)
         g.save(output)
         exit()
 

--- a/src/pecanpy/cli.py
+++ b/src/pecanpy/cli.py
@@ -154,7 +154,7 @@ def parse_args():
     parser.add_argument(
         "--delimiter",
         type=str,
-        default='\t',
+        default="\t",
         help="Delimiter used bewteen node IDs.",
     )
 

--- a/src/pecanpy/cli.py
+++ b/src/pecanpy/cli.py
@@ -268,8 +268,10 @@ def read_graph(args):
     pecanpy_mode = getattr(pecanpy, mode, None)
     g = pecanpy_mode(p, q, workers, verbose, extend, gamma)
 
-    read_func = g.read_npz if fp.endswith(".npz") else g.read_edg
-    read_func(fp, weighted, directed)
+    if fp.endswith(".npz"):
+        g.read_npz(fp, weighted)
+    else:
+        g.read_edg(fp, weighted, directed, delimiter)
 
     check_mode(g, args)
 

--- a/src/pecanpy/graph.py
+++ b/src/pecanpy/graph.py
@@ -335,7 +335,7 @@ class SparseGraph(BaseGraph):
         """Return the number of edges in the graph."""
         return self.indptr[-1]
 
-    def read_edg(self, edg_fp, weighted, directed):
+    def read_edg(self, edg_fp, weighted, directed, delimeter='\t'):
         """Create CSR sparse graph from edge list.
 
         First create ``AdjlstGraph`` by reading the edge list file, and then
@@ -345,10 +345,11 @@ class SparseGraph(BaseGraph):
             edg_fp (str): path to edgelist file.
             weighted (bool): whether the graph is weighted.
             directed (bool): whether the graph is directed.
+            delimiter (str): delimiter used between node IDs.
 
         """
         g = AdjlstGraph()
-        g.read(edg_fp, weighted, directed)
+        g.read(edg_fp, weighted, directed, delimeter)
         self.set_ids(g.IDlst)
         self.indptr, self.indices, self.data = g.to_csr()
 

--- a/src/pecanpy/graph.py
+++ b/src/pecanpy/graph.py
@@ -335,7 +335,7 @@ class SparseGraph(BaseGraph):
         """Return the number of edges in the graph."""
         return self.indptr[-1]
 
-    def read_edg(self, edg_fp, weighted, directed, delimeter="\t"):
+    def read_edg(self, edg_fp, weighted, directed, delimiter="\t"):
         """Create CSR sparse graph from edge list.
 
         First create ``AdjlstGraph`` by reading the edge list file, and then
@@ -349,11 +349,11 @@ class SparseGraph(BaseGraph):
 
         """
         g = AdjlstGraph()
-        g.read(edg_fp, weighted, directed, delimeter)
+        g.read(edg_fp, weighted, directed, delimiter)
         self.set_ids(g.IDlst)
         self.indptr, self.indices, self.data = g.to_csr()
 
-    def read_npz(self, fp, weighted, directed):
+    def read_npz(self, fp, weighted):
         """Directly read a CSR sparse graph.
 
         Note:
@@ -467,14 +467,13 @@ class DenseGraph(BaseGraph):
         self.data = data
         self.nonzero = data != 0
 
-    def read_npz(self, fp, weighted, directed):
+    def read_npz(self, fp, weighted):
         """Read ``.npz`` file and create dense graph.
 
         Args:
             fp (str): path to ``.npz`` file.
             weighted (bool): whether the graph is weighted, if unweighted,
                 all none zero weights will be converted to 1.
-            directed (bool): not used, for compatibility with ``SparseGraph``.
 
         """
         raw = np.load(fp)

--- a/src/pecanpy/graph.py
+++ b/src/pecanpy/graph.py
@@ -335,7 +335,7 @@ class SparseGraph(BaseGraph):
         """Return the number of edges in the graph."""
         return self.indptr[-1]
 
-    def read_edg(self, edg_fp, weighted, directed, delimeter='\t'):
+    def read_edg(self, edg_fp, weighted, directed, delimeter="\t"):
         """Create CSR sparse graph from edge list.
 
         First create ``AdjlstGraph`` by reading the edge list file, and then
@@ -483,10 +483,10 @@ class DenseGraph(BaseGraph):
             self.data = self.nonzero * 1.0
         self.set_ids(raw["IDs"].tolist())
 
-    def read_edg(self, edg_fp, weighted, directed):
+    def read_edg(self, edg_fp, weighted, directed, delimiter='\t'):
         """Read an edgelist file and construct dense graph."""
         g = AdjlstGraph()
-        g.read(edg_fp, weighted, directed)
+        g.read(edg_fp, weighted, directed, delimiter)
 
         self.set_ids(g.IDlst)
         self._set_data(g.to_dense())

--- a/src/pecanpy/graph.py
+++ b/src/pecanpy/graph.py
@@ -482,7 +482,7 @@ class DenseGraph(BaseGraph):
             self.data = self.nonzero * 1.0
         self.set_ids(raw["IDs"].tolist())
 
-    def read_edg(self, edg_fp, weighted, directed, delimiter='\t'):
+    def read_edg(self, edg_fp, weighted, directed, delimiter="\t"):
         """Read an edgelist file and construct dense graph."""
         g = AdjlstGraph()
         g.read(edg_fp, weighted, directed, delimiter)


### PR DESCRIPTION
Prior to this request whenever an edgelist without tab spaces between the node ids was used the cli would return 
`IndexError: list index out of range`

All I did was add the `delimiter` argument and pass it through the various functions.

I also rewrote the logic for calling the `read_npz` function so that unused args (such as `directed` and `delimiter`) are not passed through.

I added a line in the `README.md` to note the added functionality.