### PR TITLE
Random seed for random walk generation

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest==6.2.5
 pytest-cov==3.0.0
 twine==3.4.1
 pre-commit==2.16.0
+parameterized==0.8.1

--- a/src/pecanpy/cli.py
+++ b/src/pecanpy/cli.py
@@ -152,6 +152,13 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--random_state",
+        type=int,
+        default=None,
+        help="Random seed for generating random walks.",
+    )
+
+    parser.add_argument(
         "--delimiter",
         type=str,
         default="\t",
@@ -249,6 +256,7 @@ def read_graph(args):
     directed = args.directed
     extend = args.extend
     gamma = args.gamma
+    random_state = args.random_state
     mode = args.mode
     task = args.task
     delimiter = args.delimiter
@@ -266,7 +274,7 @@ def read_graph(args):
         exit()
 
     pecanpy_mode = getattr(pecanpy, mode, None)
-    g = pecanpy_mode(p, q, workers, verbose, extend, gamma)
+    g = pecanpy_mode(p, q, workers, verbose, extend, gamma, random_state)
 
     if fp.endswith(".npz"):
         g.read_npz(fp, weighted)

--- a/src/pecanpy/graph.py
+++ b/src/pecanpy/graph.py
@@ -466,7 +466,7 @@ class DenseGraph(BaseGraph):
 
     def _set_data(self, data):
         """Set data and update nonzero."""
-        self.data = data
+        self.data = data.astype(float)
         self.nonzero = data != 0
 
     def read_npz(self, fp, weighted):
@@ -520,7 +520,6 @@ class DenseGraph(BaseGraph):
 
         """
         g = cls(**kwargs)
-        g.data = adj_mat
-        g.nonzero = adj_mat != 0
+        g._set_data(adj_mat)
         g.set_ids(node_ids)
         return g

--- a/src/pecanpy/graph.py
+++ b/src/pecanpy/graph.py
@@ -456,18 +456,29 @@ class DenseGraph(BaseGraph):
     def __init__(self):
         """Initialize DenseGraph object."""
         super().__init__()
-        self.data = None
-        self.nonzero = None
+        self._data = None
+        self._nonzero = None
 
     @property
     def num_edges(self):
         """Return the number of edges in the graph."""
         return self.nonzero.sum()
 
-    def _set_data(self, data):
-        """Set data and update nonzero."""
-        self.data = data.astype(float)
-        self.nonzero = data != 0
+    @property
+    def data(self):
+        """Return the adjacency matrix."""
+        return self._data
+
+    @property
+    def nonzero(self):
+        """Return the nonzero mask for the adjacency matrix."""
+        return self._nonzero
+
+    @data.setter
+    def data(self, data):
+        """Set adjacency matrix and the corresponding nonzero matrix."""
+        self._data = data.astype(float)
+        self._nonzero = self._data != 0
 
     def read_npz(self, fp, weighted):
         """Read ``.npz`` file and create dense graph.
@@ -479,7 +490,7 @@ class DenseGraph(BaseGraph):
 
         """
         raw = np.load(fp)
-        self._set_data(raw["data"])
+        self.data = raw["data"]
         if not weighted:  # overwrite edge weights with constant
             self.data = self.nonzero * 1.0
         self.set_ids(raw["IDs"].tolist())
@@ -490,7 +501,7 @@ class DenseGraph(BaseGraph):
         g.read(edg_fp, weighted, directed, delimiter)
 
         self.set_ids(g.IDlst)
-        self._set_data(g.to_dense())
+        self.data = g.to_dense()
 
     def save(self, fp):
         """Save dense graph  as ``.dense.npz`` file."""
@@ -507,7 +518,7 @@ class DenseGraph(BaseGraph):
         """
         g = cls(**kwargs)
         g.set_ids(adjlst_graph.IDlst)
-        g._set_data(adjlst_graph.to_dense())
+        g.data = adjlst_graph.to_dense()
         return g
 
     @classmethod
@@ -520,6 +531,6 @@ class DenseGraph(BaseGraph):
 
         """
         g = cls(**kwargs)
-        g._set_data(adj_mat)
+        g.data = adj_mat
         g.set_ids(node_ids)
         return g

--- a/src/pecanpy/pecanpy.py
+++ b/src/pecanpy/pecanpy.py
@@ -3,6 +3,7 @@ import numpy as np
 from gensim.models import Word2Vec
 from numba import njit, prange
 from numba_progress import ProgressBar
+from numba.np.ufunc.parallel import _get_thread_id
 from pecanpy.rw import DenseRWGraph, SparseRWGraph
 from pecanpy.wrappers import Timer
 
@@ -41,32 +42,45 @@ class Base:
 
     """
 
-    def __init__(self, p, q, workers, verbose=False, extend=False, gamma=0):
+    def __init__(
+        self,
+        p=1,
+        q=1,
+        workers=1,
+        verbose=False,
+        extend=False,
+        gamma=0,
+        random_state=None,
+    ):
         """Initializ node2vec base class.
 
         Args:
             p (float): return parameter, value less than 1 encourages returning
-                back to previous vertex, and discourage for value grater than 1.
+                back to previous vertex, and discourage for value grater than 1
+                (default: 1).
             q (float): in-out parameter, value less than 1 encourages walks to
                 go "outward", and value greater than 1 encourage walking within
-                a localized neighborhood.
-            workers (int):  number of threads to be spawned for runing node2vec
-                including walk generation and word2vec embedding.
+                a localized neighborhood (default: 1)
+            workers (int): number of threads to be spawned for runing node2vec
+                including walk generation and word2vec embedding (default: 1)
             verbose (bool): show progress bar for walk generation.
             extend (bool): use node2vec+ extension if set to :obj:`True`
                 (default: :obj:`False`).
             gamma (float): Multiplication factor for the std term of edge
                 weights added to the average edge weights as the noisy edge
                 threashold, only used by node2vec+ (default: 0)
+            random_state (int, optional): Random seed for generating random
+                walks (default: :obj:`None`).
 
         """
         super().__init__()
         self.p = p
         self.q = q
-        self.workers = workers
+        self.workers = workers  # TODO: not doing anything, need to fix.
         self.verbose = verbose
         self.extend = extend
         self.gamma = gamma
+        self.random_state = random_state
 
     def _map_walk(self, walk_idx_ary):
         """Map walk from node index to node ID.
@@ -97,8 +111,11 @@ class Base:
         num_nodes = len(self.IDlst)
         nodes = np.array(range(num_nodes), dtype=np.uint32)
         start_node_idx_ary = np.concatenate([nodes] * num_walks)
-        np.random.shuffle(start_node_idx_ary)
         tot_num_jobs = start_node_idx_ary.size
+
+        random_state = self.random_state
+        np.random.seed(random_state)
+        np.random.shuffle(start_node_idx_ary)  # for balanced work load
 
         move_forward = self.get_move_forward()
         has_nbrs = self.get_has_nbrs()
@@ -107,6 +124,9 @@ class Base:
         @njit(parallel=True, nogil=True)
         def node2vec_walks(num_iter, progress_proxy):
             """Simulate a random walk starting from start node."""
+            # Seed the random number generator
+            np.random.seed(random_state + _get_thread_id())
+
             # use the last entry of each walk index array to keep track of the
             # effective walk length
             walk_idx_mat = np.zeros((num_iter, walk_length + 2), dtype=np.uint32)

--- a/src/pecanpy/pecanpy.py
+++ b/src/pecanpy/pecanpy.py
@@ -81,6 +81,7 @@ class Base:
         self.extend = extend
         self.gamma = gamma
         self.random_state = random_state
+        self._preprocessed = False
 
     def _map_walk(self, walk_idx_ary):
         """Map walk from node index to node ID.
@@ -108,6 +109,8 @@ class Base:
             walks_length (int): length of walk.
 
         """
+        self._preprocess_transition_probs()
+
         num_nodes = len(self.IDlst)
         nodes = np.array(range(num_nodes), dtype=np.uint32)
         start_node_idx_ary = np.concatenate([nodes] * num_walks)
@@ -188,6 +191,11 @@ class Base:
     def preprocess_transition_probs(self):
         """Null default preprocess method."""
         pass
+
+    def _preprocess_transition_probs(self):
+        if not self._preprocessed:
+            self.preprocess_transition_probs()
+            self._preprocessed = True
 
     def embed(
         self,

--- a/src/pecanpy/pecanpy.py
+++ b/src/pecanpy/pecanpy.py
@@ -2,8 +2,8 @@
 import numpy as np
 from gensim.models import Word2Vec
 from numba import njit, prange
-from numba_progress import ProgressBar
 from numba.np.ufunc.parallel import _get_thread_id
+from numba_progress import ProgressBar
 from pecanpy.rw import DenseRWGraph, SparseRWGraph
 from pecanpy.wrappers import Timer
 
@@ -125,7 +125,8 @@ class Base:
         def node2vec_walks(num_iter, progress_proxy):
             """Simulate a random walk starting from start node."""
             # Seed the random number generator
-            np.random.seed(random_state + _get_thread_id())
+            if random_state is not None:
+                np.random.seed(random_state + _get_thread_id())
 
             # use the last entry of each walk index array to keep track of the
             # effective walk length

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,5 +1,5 @@
 import os
-import os.path as op
+import os.path as osp
 import shutil
 import subprocess
 import tempfile
@@ -11,12 +11,12 @@ from pecanpy import cli
 
 set_num_threads(1)
 
-DATA_DIR = op.abspath(op.join(__file__, op.pardir, op.pardir, "demo"))
-EDG_FP = op.join(DATA_DIR, "karate.edg")
+DATA_DIR = osp.abspath(osp.join(__file__, osp.pardir, osp.pardir, "demo"))
+EDG_FP = osp.join(DATA_DIR, "karate.edg")
 
 TMP_DATA_DIR = tempfile.mkdtemp()
-CSR_FP = op.join(TMP_DATA_DIR, "karate.csr.npz")
-DENSE_FP = op.join(TMP_DATA_DIR, "karate.dense.npz")
+CSR_FP = osp.join(TMP_DATA_DIR, "karate.csr.npz")
+DENSE_FP = osp.join(TMP_DATA_DIR, "karate.dense.npz")
 COM = ["pecanpy", "--input", EDG_FP, "--output"]
 
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -7,6 +7,7 @@ import unittest
 from unittest.mock import patch
 
 from numba import set_num_threads
+from parameterized import parameterized
 from pecanpy import cli
 
 set_num_threads(1)
@@ -18,6 +19,14 @@ TMP_DATA_DIR = tempfile.mkdtemp()
 CSR_FP = osp.join(TMP_DATA_DIR, "karate.csr.npz")
 DENSE_FP = osp.join(TMP_DATA_DIR, "karate.dense.npz")
 COM = ["pecanpy", "--input", EDG_FP, "--output"]
+
+SETTINGS = [
+    ("FirstOrderUnweighted",),
+    ("PreCompFirstOrder",),
+    ("PreComp",),
+    ("SparseOTF",),
+    ("DenseOTF",),
+]
 
 
 class TestCli(unittest.TestCase):
@@ -69,35 +78,13 @@ class TestCli(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     self.execute("PreCompFirstOrder", EDG_FP, p, q)
 
-    def test_firstorderunweighted_from_edg(self):
-        self.execute("FirstOrderUnweighted", EDG_FP)
+    @parameterized.expand(SETTINGS)
+    def test_from_edg(self, name):
+        self.execute(name, EDG_FP)
 
-    def test_precompfirstorder_from_edg(self):
-        self.execute("PreCompFirstOrder", EDG_FP)
-
-    def test_precomp_from_edg(self):
-        self.execute("PreComp", EDG_FP)
-
-    def test_sparseotf_from_edg(self):
-        self.execute("SparseOTF", EDG_FP)
-
-    def test_denseotf_from_edg(self):
-        self.execute("DenseOTF", EDG_FP)
-
-    def test_firstorderunweighted_from_csr(self):
-        self.execute("FirstOrderUnweighted", CSR_FP)
-
-    def test_precompfirstorder_from_npz(self):
-        self.execute("PreCompFirstOrder", CSR_FP)
-
-    def test_precomp_from_npz(self):
-        self.execute("PreComp", CSR_FP)
-
-    def test_sparseotf_from_npz(self):
-        self.execute("SparseOTF", CSR_FP)
-
-    def test_denseotf_from_npz(self):
-        self.execute("DenseOTF", DENSE_FP)
+    @parameterized.expand(SETTINGS)
+    def test_from_npz(self, name):
+        self.execute(name, DENSE_FP if name == "DenseOTF" else CSR_FP)
 
 
 if __name__ == "__main__":

--- a/test/test_pecanpy.py
+++ b/test/test_pecanpy.py
@@ -2,6 +2,7 @@ import os.path as osp
 import unittest
 
 from numba import set_num_threads
+from parameterized import parameterized
 from pecanpy import graph
 from pecanpy import pecanpy
 
@@ -9,66 +10,35 @@ set_num_threads(1)
 
 DATA_DIR = osp.abspath(osp.join(__file__, osp.pardir, osp.pardir, "demo"))
 EDG_FP = osp.join(DATA_DIR, "karate.edg")
+SETTINGS = [
+    ("SparseOTF", pecanpy.SparseOTF),
+    ("DenseOTF", pecanpy.DenseOTF),
+    ("PreComp", pecanpy.PreComp),
+    ("PreCompFirstOrder", pecanpy.PreCompFirstOrder),
+    ("FirstOrderUnweighted", pecanpy.FirstOrderUnweighted),
+]
 
 
-class TestPecanPyFromMat(unittest.TestCase):
-    def setUp(self):
+class TestPecanPy(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
         g = graph.DenseGraph()
         g.read_edg(EDG_FP, weighted=False, directed=False)
         self.mat = g.data
         self.ids = g.IDlst
-        self.kwargs = {"p": 1, "q": 1, "workers": 1}
 
-    def test_sparseotf_from_mat(self):
-        g = pecanpy.SparseOTF.from_mat(self.mat, self.ids, **self.kwargs)
-        g.embed()
+    @parameterized.expand(SETTINGS)
+    def test_from_mat(self, name, mode):
+        with self.subTest(name):
+            g = mode.from_mat(self.mat, self.ids, p=1, q=1)
+            g.embed()
 
-    def test_denseotf_from_mat(self):
-        g = pecanpy.DenseOTF.from_mat(self.mat, self.ids, **self.kwargs)
-        g.embed()
-
-    def test_precomp_from_mat(self):
-        g = pecanpy.PreComp.from_mat(self.mat, self.ids, **self.kwargs)
-        g.preprocess_transition_probs()
-        g.embed()
-
-    def test_precompfirtorder_from_mat(self):
-        g = pecanpy.PreCompFirstOrder.from_mat(self.mat, self.ids, **self.kwargs)
-        g.preprocess_transition_probs()
-        g.embed()
-
-    def test_firtorderunweighted_from_mat(self):
-        g = pecanpy.FirstOrderUnweighted.from_mat(self.mat, self.ids, **self.kwargs)
-        g.embed()
-
-
-class TestPecanPyFromEdg(unittest.TestCase):
-    def test_sparseotf_from_edg(self):
-        g = pecanpy.SparseOTF(1, 1, 1)
-        g.read_edg(EDG_FP, weighted=False, directed=False)
-        g.embed()
-
-    def test_denseotf_from_edg(self):
-        g = pecanpy.DenseOTF(1, 1, 1)
-        g.read_edg(EDG_FP, weighted=False, directed=False)
-        g.embed()
-
-    def test_precomp_from_edg(self):
-        g = pecanpy.PreComp(1, 1, 1)
-        g.read_edg(EDG_FP, weighted=False, directed=False)
-        g.preprocess_transition_probs()
-        g.embed()
-
-    def test_precompfirstorder_from_edg(self):
-        g = pecanpy.PreCompFirstOrder(1, 1, 1)
-        g.read_edg(EDG_FP, weighted=False, directed=False)
-        g.preprocess_transition_probs()
-        g.embed()
-
-    def test_firstorderunweighted_from_edg(self):
-        g = pecanpy.FirstOrderUnweighted(1, 1, 1)
-        g.read_edg(EDG_FP, weighted=False, directed=False)
-        g.embed()
+    @parameterized.expand(SETTINGS)
+    def test_from_edg(self, name, mode):
+        with self.subTest(name):
+            g = mode(p=1, q=1)
+            g.read_edg(EDG_FP, weighted=False, directed=False)
+            g.embed()
 
 
 if __name__ == "__main__":

--- a/test/test_pecanpy.py
+++ b/test/test_pecanpy.py
@@ -1,4 +1,4 @@
-import os.path as op
+import os.path as osp
 import unittest
 
 from numba import set_num_threads
@@ -7,8 +7,8 @@ from pecanpy import pecanpy
 
 set_num_threads(1)
 
-DATA_DIR = op.abspath(op.join(__file__, op.pardir, op.pardir, "demo"))
-EDG_FP = op.join(DATA_DIR, "karate.edg")
+DATA_DIR = osp.abspath(osp.join(__file__, osp.pardir, osp.pardir, "demo"))
+EDG_FP = osp.join(DATA_DIR, "karate.edg")
 
 
 class TestPecanPyFromMat(unittest.TestCase):

--- a/test/test_walk.py
+++ b/test/test_walk.py
@@ -19,31 +19,45 @@ MAT = np.array(
 )
 IDS = ["a", "b", "c", "d", "e"]
 
-FIRST_ORDER_WALK_SEED0 = [
-    ["c", "b", "c", "d"],
-    ["d", "c", "d", "e"],
-    ["e", "d", "c", "b"],
-    ["e", "d", "c", "b"],
-    ["b", "a", "b", "a"],
-    ["b", "a", "b", "c"],
-    ["c", "e", "d", "e"],
-    ["d", "c", "b", "c"],
-    ["a", "b", "c", "d"],
-    ["a", "b", "c", "b"],
-]
+WALKS = {
+    "FirstOrderUnweighted": [
+        ["c", "b", "c", "d"],
+        ["d", "c", "d", "e"],
+        ["e", "d", "c", "b"],
+        ["e", "d", "c", "b"],
+        ["b", "a", "b", "a"],
+        ["b", "a", "b", "c"],
+        ["c", "e", "d", "e"],
+        ["d", "c", "b", "c"],
+        ["a", "b", "c", "d"],
+        ["a", "b", "c", "b"],
+    ],
+    "SparseOTF": [
+        ["c", "d", "e", "d"],
+        ["d", "e", "c", "d"],
+        ["e", "c", "e", "d"],
+        ["e", "c", "e", "d"],
+        ["b", "c", "e", "c"],
+        ["b", "a", "b", "c"],
+        ["c", "e", "d", "e"],
+        ["d", "e", "c", "e"],
+        ["a", "b", "c", "b"],
+        ["a", "b", "c", "d"],
+    ],
+}
 
 
 class TestWalk(unittest.TestCase):
     @parameterized.expand(
         [
-            (pecanpy.FirstOrderUnweighted,),
+            ("FirstOrderUnweighted", pecanpy.FirstOrderUnweighted),
+            ("SparseOTF", pecanpy.SparseOTF),
         ],
     )
-    def test_first_order_unweighted(self, mode):
-        print(mode)
+    def test_first_order_unweighted(self, name, mode):
         graph = mode.from_mat(MAT, IDS, p=1, q=1, random_state=0)
         walks = graph.simulate_walks(2, 3)
-        self.assertEqual(walks, FIRST_ORDER_WALK_SEED0)
+        self.assertEqual(walks, WALKS[name])
         print(walks)
 
 

--- a/test/test_walk.py
+++ b/test/test_walk.py
@@ -32,6 +32,30 @@ WALKS = {
         ["a", "b", "c", "d"],
         ["a", "b", "c", "b"],
     ],
+    "PreCompFirstOrder": [
+        ["c", "d", "e", "d"],
+        ["d", "c", "d", "e"],
+        ["e", "d", "c", "e"],
+        ["e", "d", "e", "c"],
+        ["b", "c", "e", "c"],
+        ["b", "c", "d", "c"],
+        ["c", "d", "e", "d"],
+        ["d", "c", "e", "d"],
+        ["a", "b", "a", "b"],
+        ["a", "b", "c", "e"],
+    ],
+    "PreComp": [
+        ["c", "d", "e", "d"],
+        ["d", "c", "d", "e"],
+        ["e", "d", "c", "e"],
+        ["e", "d", "e", "c"],
+        ["b", "c", "e", "c"],
+        ["b", "c", "d", "c"],
+        ["c", "d", "e", "d"],
+        ["d", "c", "e", "d"],
+        ["a", "b", "a", "b"],
+        ["a", "b", "c", "e"],
+    ],
     "SparseOTF": [
         ["c", "d", "e", "d"],
         ["d", "e", "c", "d"],
@@ -63,12 +87,15 @@ class TestWalk(unittest.TestCase):
     @parameterized.expand(
         [
             ("FirstOrderUnweighted", pecanpy.FirstOrderUnweighted),
+            ("PreCompFirstOrder", pecanpy.PreComp),
+            ("PreComp", pecanpy.PreComp),
             ("SparseOTF", pecanpy.SparseOTF),
             ("DenseOTF", pecanpy.DenseOTF),
         ],
     )
     def test_first_order_unweighted(self, name, mode):
         graph = mode.from_mat(MAT, IDS, p=1, q=1, random_state=0)
+        graph.preprocess_transition_probs()  # TODO: remove.
         walks = graph.simulate_walks(2, 3)
         self.assertEqual(walks, WALKS[name])
         print(walks)

--- a/test/test_walk.py
+++ b/test/test_walk.py
@@ -95,7 +95,6 @@ class TestWalk(unittest.TestCase):
     )
     def test_first_order_unweighted(self, name, mode):
         graph = mode.from_mat(MAT, IDS, p=1, q=1, random_state=0)
-        graph.preprocess_transition_probs()  # TODO: remove.
         walks = graph.simulate_walks(2, 3)
         self.assertEqual(walks, WALKS[name])
         print(walks)

--- a/test/test_walk.py
+++ b/test/test_walk.py
@@ -1,0 +1,51 @@
+import unittest
+import os.path as osp
+
+import numpy as np
+from numba import set_num_threads
+from parameterized import parameterized
+from pecanpy import pecanpy
+
+set_num_threads(1)
+
+MAT = np.array(
+    [
+        [0, 1, 0, 0, 0],
+        [1, 0, 1, 0, 0],
+        [0, 1, 0, 1, 1],
+        [0, 0, 1, 0, 1],
+        [0, 0, 1, 1, 0],
+    ],
+)
+IDS = ["a", "b", "c", "d", "e"]
+
+FIRST_ORDER_WALK_SEED0 = [
+    ["c", "b", "c", "d"],
+    ["d", "c", "d", "e"],
+    ["e", "d", "c", "b"],
+    ["e", "d", "c", "b"],
+    ["b", "a", "b", "a"],
+    ["b", "a", "b", "c"],
+    ["c", "e", "d", "e"],
+    ["d", "c", "b", "c"],
+    ["a", "b", "c", "d"],
+    ["a", "b", "c", "b"],
+]
+
+
+class TestWalk(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (pecanpy.FirstOrderUnweighted,),
+        ],
+    )
+    def test_first_order_unweighted(self, mode):
+        print(mode)
+        graph = mode.from_mat(MAT, IDS, p=1, q=1, random_state=0)
+        walks = graph.simulate_walks(2, 3)
+        self.assertEqual(walks, FIRST_ORDER_WALK_SEED0)
+        print(walks)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_walk.py
+++ b/test/test_walk.py
@@ -44,6 +44,18 @@ WALKS = {
         ["a", "b", "c", "b"],
         ["a", "b", "c", "d"],
     ],
+    "DenseOTF": [
+        ["c", "d", "e", "d"],
+        ["d", "e", "c", "d"],
+        ["e", "c", "e", "d"],
+        ["e", "c", "e", "d"],
+        ["b", "c", "e", "c"],
+        ["b", "a", "b", "c"],
+        ["c", "e", "d", "e"],
+        ["d", "e", "c", "e"],
+        ["a", "b", "c", "b"],
+        ["a", "b", "c", "d"],
+    ],
 }
 
 
@@ -52,6 +64,7 @@ class TestWalk(unittest.TestCase):
         [
             ("FirstOrderUnweighted", pecanpy.FirstOrderUnweighted),
             ("SparseOTF", pecanpy.SparseOTF),
+            ("DenseOTF", pecanpy.DenseOTF),
         ],
     )
     def test_first_order_unweighted(self, name, mode):


### PR DESCRIPTION
* Set random seed for random walk generation via the ``--random_state`` cli option or set the ``random_state`` kwarg when creating the pecanpy graph.
* Automatically run ``preprocess_transition_probs`` when necessary.
Minor changes
* Refactor tests using [``parameterized``](https://pypi.org/project/parameterized/) to reduce redundancies