### PR TITLE
Static typing and format fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,12 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-added-large-files
 
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.6.0
+    hooks:
+    -   id: reorder-python-imports
+        args: ["--py38-plus"]
+
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,4 +8,3 @@ sphinx:
 python:
     install:
         - requirements: docs/requirements.txt
-

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ node_id dim_1 dim_2 ... dim_d
 
 ### Development Note
 
-Run `black src/pecanpy/` to automatically follow black code formatting.  
+Run `black src/pecanpy/` to automatically follow black code formatting.
 Run `tox -e flake8` and resolve suggestions before committing to ensure consistent code style.
 
 ## Additional Information
@@ -134,10 +134,10 @@ For support please contact [Remy Liu](https://twitter.com/RemyLau3) at liurenmi@
 This repository and all its contents are released under the [BSD 3-Clause License](https://opensource.org/licenses/BSD-3-Clause); See [LICENSE.md](https://github.com/krishnanlab/pecanpy/blob/master/LICENSE.md).
 
 ### Citation
-If you use PecanPy, please cite:  
+If you use PecanPy, please cite:
 Liu R, Krishnan A (2021) **PecanPy: a fast, efficient, and parallelized Python implementation of node2vec.** _Bioinformatics_ https://doi.org/10.1093/bioinformatics/btab202
 
-If you find _node2vec+_ useful, please cite:  
+If you find _node2vec+_ useful, please cite:
 Liu R, Hirn M, Krishnan A (2021) **Accurately Modeling Biased Random Walks on Weighted Wraphs Using Node2vec+.** _axXiv_ https://arxiv.org/abs/2109.08031
 
 ### Authors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools>=42.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.mypy]
+ignore_missing_imports = true
+follow_imports = "skip"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-cov==3.0.0
 twine==3.4.1
 pre-commit==2.16.0
 parameterized==0.8.1
+mypy==0.931

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ tox==3.24.4
 black==21.12b0
 pytest==6.2.5
 pytest-cov==3.0.0
+pytest-xdist==2.5.0
 twine==3.4.1
 pre-commit==2.16.0
 parameterized==0.8.1

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-
 """Setup module."""
-
 import setuptools
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     setuptools.setup()

--- a/src/pecanpy/__init__.py
+++ b/src/pecanpy/__init__.py
@@ -1,5 +1,4 @@
 """PecanPy: parallelized, efficient, and accelerated node2vec."""
-
 from . import graph
 from . import pecanpy
 

--- a/src/pecanpy/cli.py
+++ b/src/pecanpy/cli.py
@@ -247,7 +247,7 @@ def read_graph(args):
     (``DenseOTF``).
 
     """
-    fp = args.input
+    path = args.input
     output = args.output
     p = args.p
     q = args.q
@@ -270,17 +270,17 @@ def read_graph(args):
 
     if task in ["tocsr", "todense"]:  # perform conversion then save and exit
         g = graph.SparseGraph() if task == "tocsr" else graph.DenseGraph()
-        g.read_edg(fp, weighted, directed, delimiter)
+        g.read_edg(path, weighted, directed, delimiter)
         g.save(output)
         exit()
 
     pecanpy_mode = getattr(pecanpy, mode, None)
     g = pecanpy_mode(p, q, workers, verbose, extend, gamma, random_state)
 
-    if fp.endswith(".npz"):
-        g.read_npz(fp, weighted)
+    if path.endswith(".npz"):
+        g.read_npz(path, weighted)
     else:
-        g.read_edg(fp, weighted, directed, delimiter)
+        g.read_edg(path, weighted, directed, delimiter)
 
     check_mode(g, args)
 
@@ -300,11 +300,11 @@ def learn_embeddings(args, walks):
         epochs=args.epochs,
     )
 
-    output_fp = args.output
-    if output_fp.endswith(".npz"):
-        np.savez(output_fp, IDs=model.wv.index_to_key, data=model.wv.vectors)
+    output_path = args.output
+    if output_path.endswith(".npz"):
+        np.savez(output_path, IDs=model.wv.index_to_key, data=model.wv.vectors)
     else:
-        model.wv.save_word2vec_format(output_fp)
+        model.wv.save_word2vec_format(output_path)
 
 
 @Timer("pre-compute transition probabilities")

--- a/src/pecanpy/cli.py
+++ b/src/pecanpy/cli.py
@@ -12,14 +12,15 @@ Examples:
         $ pecanpy --help
 
 """
-
 import argparse
 
 import numba
 import numpy as np
 from gensim.models import Word2Vec
-from pecanpy import graph, pecanpy
-from pecanpy.wrappers import Timer
+
+from . import graph
+from . import pecanpy
+from .wrappers import Timer
 
 
 def parse_args():

--- a/src/pecanpy/graph.py
+++ b/src/pecanpy/graph.py
@@ -18,7 +18,7 @@ class BaseGraph:
     def __init__(self):
         """Initialize ID list and ID map."""
         self._node_ids = []
-        self.IDmap = {}  # id -> index
+        self._node_idmap = {}  # id -> index
 
     @property
     def nodes(self):
@@ -46,11 +46,12 @@ class BaseGraph:
     def set_ids(self, ids):
         """Update ID list and mapping.
 
-        Set _node_ids given the input ids and also set the IDmap based on it.
+        Set _node_ids given the input ids and also set the corresponding
+        _node_idmap based on it, which maps from node ID to the index.
 
         """
         self._node_ids = ids
-        self.IDmap = {j: i for i, j in enumerate(ids)}
+        self._node_idmap = {j: i for i, j in enumerate(ids)}
 
 
 class AdjlstGraph(BaseGraph):
@@ -150,7 +151,7 @@ class AdjlstGraph(BaseGraph):
     def get_node_idx(self, node_id):
         """Get index of the node and create new node when necessary."""
         self.add_node(node_id)
-        return self.IDmap[node_id]
+        return self._node_idmap[node_id]
 
     def add_node(self, node_id):
         """Create a new node.
@@ -163,8 +164,8 @@ class AdjlstGraph(BaseGraph):
             Does not raise error even if the node alrealy exists.
 
         """
-        if node_id not in self.IDmap:
-            self.IDmap[node_id] = self.num_nodes
+        if node_id not in self._node_idmap:
+            self._node_idmap[node_id] = self.num_nodes
             self.nodes.append(node_id)
             self._data.append({})
 

--- a/src/pecanpy/graph.py
+++ b/src/pecanpy/graph.py
@@ -58,6 +58,14 @@ class BaseGraph:
         self._node_ids = node_ids
         self._node_idmap = {j: i for i, j in enumerate(node_ids)}
 
+    def get_has_nbrs(self):
+        """Abstract method to be specified by derived classes."""
+        raise NotImplementedError
+
+    def get_move_forward(self):
+        """Abstract method to be specified by derived classes."""
+        raise NotImplementedError
+
 
 class AdjlstGraph(BaseGraph):
     """Adjacency list Graph object used for reading/writing edge list files.

--- a/src/pecanpy/graph.py
+++ b/src/pecanpy/graph.py
@@ -469,16 +469,16 @@ class DenseGraph(BaseGraph):
         """Return the adjacency matrix."""
         return self._data
 
-    @property
-    def nonzero(self):
-        """Return the nonzero mask for the adjacency matrix."""
-        return self._nonzero
-
     @data.setter
     def data(self, data):
         """Set adjacency matrix and the corresponding nonzero matrix."""
         self._data = data.astype(float)
         self._nonzero = self._data != 0
+
+    @property
+    def nonzero(self):
+        """Return the nonzero mask for the adjacency matrix."""
+        return self._nonzero
 
     def read_npz(self, fp, weighted):
         """Read ``.npz`` file and create dense graph.

--- a/src/pecanpy/pecanpy.py
+++ b/src/pecanpy/pecanpy.py
@@ -1,4 +1,7 @@
 """Different strategies for generating node2vec walks."""
+from typing import List
+from typing import Optional
+
 import numpy as np
 from gensim.models import Word2Vec
 from numba import njit
@@ -6,12 +9,13 @@ from numba import prange
 from numba.np.ufunc.parallel import _get_thread_id
 from numba_progress import ProgressBar
 
+from .graph import BaseGraph
 from .rw import DenseRWGraph
 from .rw import SparseRWGraph
 from .wrappers import Timer
 
 
-class Base:
+class Base(BaseGraph):
     """Base node2vec object.
 
     This base object provides the skeleton for the node2vec walk algorithm,
@@ -47,13 +51,13 @@ class Base:
 
     def __init__(
         self,
-        p=1,
-        q=1,
-        workers=1,
-        verbose=False,
-        extend=False,
-        gamma=0,
-        random_state=None,
+        p: float = 1,
+        q: float = 1,
+        workers: int = 1,
+        verbose: bool = False,
+        extend: bool = False,
+        gamma: float = 0,
+        random_state: Optional[int] = None,
     ):
         """Initializ node2vec base class.
 
@@ -84,9 +88,9 @@ class Base:
         self.extend = extend
         self.gamma = gamma
         self.random_state = random_state
-        self._preprocessed = False
+        self._preprocessed: bool = False
 
-    def _map_walk(self, walk_idx_ary):
+    def _map_walk(self, walk_idx_ary: np.ndarray) -> List[str]:
         """Map walk from node index to node ID.
 
         Note:
@@ -99,7 +103,11 @@ class Base:
         walk = [self.nodes[i] for i in walk_idx_ary[:end_idx]]
         return walk
 
-    def simulate_walks(self, num_walks, walk_length):
+    def simulate_walks(
+        self,
+        num_walks: int,
+        walk_length: int,
+    ) -> List[List[str]]:
         """Generate walks starting from each nodes ``num_walks`` time.
 
         Note:
@@ -201,13 +209,13 @@ class Base:
 
     def embed(
         self,
-        dim=128,
-        num_walks=10,
-        walk_length=80,
-        window_size=10,
-        epochs=1,
-        verbose=False,
-    ):
+        dim: int = 128,
+        num_walks: int = 10,
+        walk_length: int = 80,
+        window_size: int = 10,
+        epochs: int = 1,
+        verbose: bool = False,
+    ) -> np.ndarray:
         """Generate embeddings.
 
         This is a shortcut function that combines ``simulate_walks`` with

--- a/src/pecanpy/pecanpy.py
+++ b/src/pecanpy/pecanpy.py
@@ -1,10 +1,12 @@
 """Different strategies for generating node2vec walks."""
 import numpy as np
 from gensim.models import Word2Vec
-from numba import njit, prange
+from numba import njit
+from numba import prange
 from numba.np.ufunc.parallel import _get_thread_id
 from numba_progress import ProgressBar
-from pecanpy.rw import DenseRWGraph, SparseRWGraph
+from pecanpy.rw import DenseRWGraph
+from pecanpy.rw import SparseRWGraph
 from pecanpy.wrappers import Timer
 
 
@@ -93,7 +95,7 @@ class Base:
 
         """
         end_idx = walk_idx_ary[-1]
-        walk = [self.IDlst[i] for i in walk_idx_ary[:end_idx]]
+        walk = [self.nodes[i] for i in walk_idx_ary[:end_idx]]
         return walk
 
     def simulate_walks(self, num_walks, walk_length):
@@ -111,8 +113,7 @@ class Base:
         """
         self._preprocess_transition_probs()
 
-        num_nodes = len(self.IDlst)
-        nodes = np.array(range(num_nodes), dtype=np.uint32)
+        nodes = np.array(range(self.num_nodes), dtype=np.uint32)
         start_node_idx_ary = np.concatenate([nodes] * num_walks)
         tot_num_jobs = start_node_idx_ary.size
 
@@ -247,7 +248,7 @@ class Base:
         )
 
         # index mapping back to node IDs
-        idx_list = [w2v.wv.get_index(i) for i in self.IDlst]
+        idx_list = [w2v.wv.get_index(i) for i in self.nodes]
 
         return w2v.wv.vectors[idx_list]
 

--- a/src/pecanpy/pecanpy.py
+++ b/src/pecanpy/pecanpy.py
@@ -5,9 +5,10 @@ from numba import njit
 from numba import prange
 from numba.np.ufunc.parallel import _get_thread_id
 from numba_progress import ProgressBar
-from pecanpy.rw import DenseRWGraph
-from pecanpy.rw import SparseRWGraph
-from pecanpy.wrappers import Timer
+
+from .rw import DenseRWGraph
+from .rw import SparseRWGraph
+from .wrappers import Timer
 
 
 class Base:

--- a/src/pecanpy/rw/__init__.py
+++ b/src/pecanpy/rw/__init__.py
@@ -1,5 +1,4 @@
 """Graph objects equipped with random walk transition functions."""
-
 from .dense_rw import DenseRWGraph
 from .sparse_rw import SparseRWGraph
 

--- a/src/pecanpy/rw/dense_rw.py
+++ b/src/pecanpy/rw/dense_rw.py
@@ -10,9 +10,8 @@ class DenseRWGraph(DenseGraph):
 
     def get_noise_thresholds(self):
         """Compute average edge weights."""
-        num_nodes = len(self.IDlst)
-        noise_threshold_ary = np.zeros(num_nodes, dtype=np.float32)
-        for i in range(num_nodes):
+        noise_threshold_ary = np.zeros(self.num_nodes, dtype=np.float32)
+        for i in range(self.num_nodes):
             weights = self.data[i, self.nonzero[i]]
             noise_threshold_ary[i] = weights.mean() + self.gamma * weights.std()
         noise_threshold_ary = np.maximum(noise_threshold_ary, 0)

--- a/src/pecanpy/rw/dense_rw.py
+++ b/src/pecanpy/rw/dense_rw.py
@@ -1,7 +1,8 @@
 """Dense Graph object equipped with random walk computation."""
 import numpy as np
 from numba import njit
-from pecanpy.graph import DenseGraph
+
+from ..graph import DenseGraph
 
 
 class DenseRWGraph(DenseGraph):

--- a/src/pecanpy/rw/sparse_rw.py
+++ b/src/pecanpy/rw/sparse_rw.py
@@ -1,7 +1,9 @@
 """Sparse Graph equipped with random walk computation."""
 import numpy as np
-from numba import boolean, njit
-from pecanpy.graph import SparseGraph
+from numba import boolean
+from numba import njit
+
+from ..graph import SparseGraph
 
 
 class SparseRWGraph(SparseGraph):

--- a/src/pecanpy/rw/sparse_rw.py
+++ b/src/pecanpy/rw/sparse_rw.py
@@ -24,9 +24,8 @@ class SparseRWGraph(SparseGraph):
         data = self.data
         indptr = self.indptr
 
-        num_nodes = len(self.IDlst)
-        noise_threshold_ary = np.zeros(num_nodes, dtype=np.float32)
-        for i in range(num_nodes):
+        noise_threshold_ary = np.zeros(self.num_nodes, dtype=np.float32)
+        for i in range(self.num_nodes):
             noise_threshold_ary[i] = (
                 data[indptr[i] : indptr[i + 1]].mean()
                 + self.gamma * data[indptr[i] : indptr[i + 1]].std()

--- a/src/pecanpy/wrappers.py
+++ b/src/pecanpy/wrappers.py
@@ -1,5 +1,4 @@
 """Wrappers used by pecanpy."""
-
 import time
 
 

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -1,10 +1,13 @@
-import tempfile
 import os
 import shutil
+import tempfile
 import unittest
 
 import numpy as np
-from pecanpy.graph import BaseGraph, AdjlstGraph, SparseGraph, DenseGraph
+from pecanpy.graph import AdjlstGraph
+from pecanpy.graph import BaseGraph
+from pecanpy.graph import DenseGraph
+from pecanpy.graph import SparseGraph
 
 MAT = np.array(
     [
@@ -78,7 +81,7 @@ class TestBaseGraph(unittest.TestCase):
         self.g.set_ids(IDS)
 
     def test_set_ids(self):
-        self.assertEqual(self.g.IDlst, IDS)
+        self.assertEqual(self.g.nodes, IDS)
         self.assertEqual(self.g.IDmap, IDMAP)
 
     def test_properties(self):
@@ -102,13 +105,13 @@ class TestAdjlstGraph(unittest.TestCase):
 
     def test_from_mat(self):
         self.assertEqual(self.g1._data, ADJLST)
-        self.assertEqual(self.g1.IDlst, IDS)
+        self.assertEqual(self.g1.nodes, IDS)
 
         self.assertEqual(self.g2._data, ADJLST2)
-        self.assertEqual(self.g2.IDlst, IDS2)
+        self.assertEqual(self.g2.nodes, IDS2)
 
         self.assertEqual(self.g3._data, ADJLST3)
-        self.assertEqual(self.g3.IDlst, IDS3)
+        self.assertEqual(self.g3.nodes, IDS3)
 
     def test_properties(self):
         self.assertEqual(self.g1.num_nodes, 3)
@@ -201,7 +204,7 @@ class TestSparseGraph(unittest.TestCase):
         self.assertTrue(np.all(self.g1.indptr == INDPTR))
         self.assertTrue(np.all(self.g1.indices == INDICES))
         self.assertTrue(np.all(self.g1.data == DATA))
-        self.assertEqual(self.g1.IDlst, IDS)
+        self.assertEqual(self.g1.nodes, IDS)
         self.assertEqual(self.g1.num_nodes, 3)
         self.assertEqual(self.g1.num_edges, 4)
         self.assertEqual(self.g1.density, 2 / 3)
@@ -209,7 +212,7 @@ class TestSparseGraph(unittest.TestCase):
         self.assertTrue(np.all(self.g2.indptr == INDPTR2))
         self.assertTrue(np.all(self.g2.indices == INDICES2))
         self.assertTrue(np.all(self.g2.data == DATA2))
-        self.assertEqual(self.g2.IDlst, IDS2)
+        self.assertEqual(self.g2.nodes, IDS2)
         self.assertEqual(self.g2.num_nodes, 5)
         self.assertEqual(self.g2.num_edges, 8)
         self.assertEqual(self.g2.density, 2 / 5)
@@ -217,7 +220,7 @@ class TestSparseGraph(unittest.TestCase):
         self.assertTrue(np.all(self.g3.indptr == INDPTR3))
         self.assertTrue(np.all(self.g3.indices == INDICES3))
         self.assertTrue(np.all(self.g3.data == DATA3))
-        self.assertEqual(self.g3.IDlst, IDS3)
+        self.assertEqual(self.g3.nodes, IDS3)
         self.assertEqual(self.g3.num_nodes, 4)
         self.assertEqual(self.g3.num_edges, 5)
         self.assertEqual(self.g3.density, 5 / 12)
@@ -242,19 +245,19 @@ class TestDenseGraph(unittest.TestCase):
 
     def validate(self):
         self.assertTrue(np.all(self.g1.data == MAT))
-        self.assertEqual(self.g1.IDlst, IDS)
+        self.assertEqual(self.g1.nodes, IDS)
         self.assertEqual(self.g1.num_nodes, 3)
         self.assertEqual(self.g1.num_edges, 4)
         self.assertEqual(self.g1.density, 2 / 3)
 
         self.assertTrue(np.all(self.g2.data == MAT2))
-        self.assertEqual(self.g2.IDlst, IDS2)
+        self.assertEqual(self.g2.nodes, IDS2)
         self.assertEqual(self.g2.num_nodes, 5)
         self.assertEqual(self.g2.num_edges, 8)
         self.assertEqual(self.g2.density, 2 / 5)
 
         self.assertTrue(np.all(self.g3.data == MAT3))
-        self.assertEqual(self.g3.IDlst, IDS3)
+        self.assertEqual(self.g3.nodes, IDS3)
         self.assertEqual(self.g3.num_nodes, 4)
         self.assertEqual(self.g3.num_edges, 5)
         self.assertEqual(self.g3.density, 5 / 12)

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -180,13 +180,17 @@ class TestAdjlstGraph(unittest.TestCase):
         }
 
         tmpdir = tempfile.mkdtemp()
-        tmpfp = os.path.join(tmpdir, "test.edg")
+        tmppath = os.path.join(tmpdir, "test.edg")
 
         for unweighted in True, False:
             for delimiter in ["\t", ","]:
-                self.g1.save(tmpfp, unweighted=unweighted, delimiter=delimiter)
+                self.g1.save(
+                    tmppath,
+                    unweighted=unweighted,
+                    delimiter=delimiter,
+                )
 
-                with open(tmpfp, "r") as f:
+                with open(tmppath, "r") as f:
                     expected_result = expected_results[(unweighted, delimiter)]
                     for line, expected_line in zip(f, expected_result):
                         self.assertEqual(line, expected_line)

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -78,11 +78,11 @@ IDMAP3 = {"a": 0, "b": 1, "c": 2, "d": 3}
 class TestBaseGraph(unittest.TestCase):
     def setUp(self):
         self.g = BaseGraph()
-        self.g.set_ids(IDS)
+        self.g.set_node_ids(IDS)
 
-    def test_set_ids(self):
+    def test_set_node_ids(self):
         self.assertEqual(self.g.nodes, IDS)
-        self.assertEqual(self.g.IDmap, IDMAP)
+        self.assertEqual(self.g._node_idmap, IDMAP)
 
     def test_properties(self):
         self.assertEqual(self.g.num_nodes, 3)

--- a/test/test_pecanpy.py
+++ b/test/test_pecanpy.py
@@ -25,7 +25,7 @@ class TestPecanPy(unittest.TestCase):
         g = graph.DenseGraph()
         g.read_edg(EDG_FP, weighted=False, directed=False)
         self.mat = g.data
-        self.ids = g.IDlst
+        self.ids = g.nodes
 
     @parameterized.expand(SETTINGS)
     def test_from_mat(self, name, mode):

--- a/test/test_walk.py
+++ b/test/test_walk.py
@@ -1,5 +1,5 @@
-import unittest
 import os.path as osp
+import unittest
 
 import numpy as np
 from numba import set_num_threads

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,11 @@ deps =
 commands =
     pytest --basetemp={envtmpdir}
 
+[testenv:mypy]
+skip_install = true
+deps = mypy
+commands = mypy src/pecanpy
+
 [testenv:flake8]
 skip_install = true
 deps =


### PR DESCRIPTION
* Typed ``graph`` objects and the base pecanpy object.
* Refactor IDlst and IDmap, access through proxies (``nodes`` and ``get_node_idx``) instead
* Optional distributed testing, e.g., ``pytest -n 8`` uses eight cores