### PR TITLE
update the current import

### DIFF
--- a/src/pecanpy/pecanpy.py
+++ b/src/pecanpy/pecanpy.py
@@ -35,7 +35,7 @@ class Base(BaseGraph):
     Examples:
         Generate node2vec embeddings
 
-        >>> from pecanpy import node2vec
+        >>> from pecanpy import pecanpy as node2vec
         >>>
         >>> # initialize node2vec object, similarly for SparseOTF and DenseOTF
         >>> g = node2vec.PreComp(p=0.5, q=1, workers=4, verbose=True)


### PR DESCRIPTION
Seems 
`from pecanpy import node2vec` will throw the error `can not found module node2vec`

After checking the code, it should work 

`from pecanpy import pecanpy as node2vec`

Feel free to edit or close the PR if I am wrong.

Thank you